### PR TITLE
Fix admin navigation hook usage

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router-dom";
 import { AdminDashboard } from "@/components/admin-dashboard";
 import { useEffect, useState } from "react";
 import { apiRequest } from "@/lib/queryClient";
@@ -13,8 +12,7 @@ import { useTheme } from "@/context/ThemeContext";
 export default function AdminPage() {
   const { color, setColor } = useTheme();
   const [draft, setDraft] = React.useState<string>(color);
-  const navigate = useNavigate();
-  const location = useLocation();
+  const [, navigate] = useLocation();
   const [checked, setChecked] = useState(false);
 
   // Password change dialog states

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -34,8 +34,9 @@ export default function Landing() {
         throw new Error(j.message || '로그인 실패');
       }
       window.location.href = '/admin';
-    } catch (e) {
-      toast({ title: '로그인 실패', description: e.message || '아이디/비밀번호를 확인해 주세요.', variant: 'destructive' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : undefined;
+      toast({ title: '로그인 실패', description: message || '아이디/비밀번호를 확인해 주세요.', variant: 'destructive' });
     }
   };
 


### PR DESCRIPTION
## Summary
- switch the admin page to use Wouter's navigation hook instead of react-router so it works within the existing router
- tighten admin login error handling to satisfy TypeScript by guarding the error message access

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4d3a5ee28832d92241842e7b3b707