### PR TITLE
feat: enable admin theme application

### DIFF
--- a/client/src/context/ThemeContext.tsx
+++ b/client/src/context/ThemeContext.tsx
@@ -10,6 +10,19 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [color, setColor] = useState<string>("#3b82f6"); // default primary
 
+  const applyThemeColor = (value: string) => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    root.style.setProperty("--theme-color", value);
+    root.style.setProperty("--accent", value);
+    root.style.setProperty("--primary", value);
+    root.style.setProperty("--ring", value);
+    root.style.setProperty("--sidebar-primary", value);
+    root.style.setProperty("--sidebar-ring", value);
+    root.style.setProperty("--sidebar-accent", value);
+    root.style.setProperty("--chart-1", value);
+  };
+
   useEffect(() => {
     try {
       const saved = localStorage.getItem("theme-color");
@@ -20,15 +33,12 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const update = (c: string) => {
     setColor(c);
     try { localStorage.setItem("theme-color", c); } catch {}
-    // also reflect to CSS var
-    const root = document.documentElement;
-    root.style.setProperty("--theme-color", c);
+    applyThemeColor(c);
   };
 
   // keep CSS variable synced (first render too)
   useEffect(() => {
-    const root = document.documentElement;
-    root.style.setProperty("--theme-color", color);
+    applyThemeColor(color);
   }, [color]);
 
   return (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -38,6 +38,7 @@
   --sidebar-accent-foreground: hsl(0, 0%, 98%);
   --sidebar-border: hsl(214, 32%, 91%);
   --sidebar-ring: hsl(217, 91%, 35%);
+  --theme-color: #3b82f6;
   --font-sans: 'Noto Sans KR', sans-serif;
   --font-serif: Georgia, serif;
   --font-mono: Menlo, monospace;
@@ -86,5 +87,21 @@
   .animate-fade-in.visible {
     opacity: 1;
     transform: translateY(0);
+  }
+
+  .bg-theme {
+    background-color: var(--theme-color);
+  }
+
+  .text-theme {
+    color: var(--theme-color);
+  }
+
+  .border-theme {
+    border-color: var(--theme-color);
+  }
+
+  .ring-theme {
+    --tw-ring-color: var(--theme-color);
   }
 }

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -11,7 +11,7 @@ import { useTheme } from "@/context/ThemeContext";
 
 export default function AdminPage() {
   const { color, setColor } = useTheme();
-  const [draft, setDraft] = React.useState<string>(color);
+  const [draft, setDraft] = useState<string>(color);
   const [, navigate] = useLocation();
   const [checked, setChecked] = useState(false);
 
@@ -38,7 +38,16 @@ export default function AdminPage() {
     })();
   }, [navigate]);
 
+  useEffect(() => {
+    setDraft(color);
+  }, [color]);
+
   if (!checked) return null;
+
+  const handleApplyTheme = () => {
+    setColor(draft);
+    navigate("/");
+  };
 
   const onSubmitChangePassword = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -137,16 +146,21 @@ export default function AdminPage() {
           />
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-600">현재 선택</span>
-            <span className="px-2 py-1 rounded border" style={{ background: draft, color: '#fff' }}>{draft}</span>
+            <span
+              className="px-2 py-1 rounded border"
+              style={{ background: draft, color: "#fff" }}
+            >
+              {draft}
+            </span>
           </div>
-          <button
-            className="ml-auto px-4 py-2 rounded-lg bg-theme text-white font-medium shadow hover:opacity-90 transition"
-            onClick={() => { setColor(draft); try { localStorage.setItem('theme-color', draft); } catch (e) {}; navigate('/'); }}
+          <Button
+            className="ml-auto min-w-[120px] text-white"
+            style={{ backgroundColor: draft, borderColor: draft }}
+            onClick={handleApplyTheme}
           >
             테마 적용
-          </button>
+          </Button>
         </div>
-        <p className="text-xs text-gray-500 mt-2">버튼을 누르면 테마가 적용되고 랜딩 페이지로 이동합니다.</p>
       </div>
 
 </div>


### PR DESCRIPTION
## Summary
- replace the theme instruction text in the admin page with a real apply button wired to navigation
- keep the color picker state in sync with the active theme and persist the chosen color
- expose CSS utilities and variable updates so the landing page reflects the selected theme color

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4d882a3f8832d8d72cfb07e96aa64