### PR TITLE
feat: add curated theme palettes

### DIFF
--- a/client/src/context/ThemeContext.tsx
+++ b/client/src/context/ThemeContext.tsx
@@ -1,39 +1,195 @@
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+type ThemeDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  preview: [string, string, string];
+  values: Record<string, string>;
+};
 
 type ThemeContextType = {
-  color: string;
-  setColor: (c: string) => void;
+  theme: ThemeDefinition;
+  themes: ThemeDefinition[];
+  setTheme: (id: string) => void;
 };
+
+export const THEMES: ThemeDefinition[] = [
+  {
+    id: "ocean-breeze",
+    name: "오션 브리즈",
+    description: "시원한 블루 톤으로 세련된 느낌의 테마",
+    preview: ["#0ea5e9", "#38bdf8", "#e0f2fe"],
+    values: {
+      "--background": "hsl(204, 100%, 97%)",
+      "--foreground": "hsl(222, 47%, 15%)",
+      "--card": "hsl(0, 0%, 100%)",
+      "--card-foreground": "hsl(222, 47%, 15%)",
+      "--popover": "hsl(0, 0%, 100%)",
+      "--popover-foreground": "hsl(222, 47%, 15%)",
+      "--primary": "hsl(204, 94%, 41%)",
+      "--primary-foreground": "hsl(0, 0%, 100%)",
+      "--secondary": "hsl(205, 90%, 92%)",
+      "--secondary-foreground": "hsl(222, 47%, 18%)",
+      "--muted": "hsl(204, 94%, 92%)",
+      "--muted-foreground": "hsl(210, 20%, 40%)",
+      "--accent": "hsl(201, 100%, 46%)",
+      "--accent-foreground": "hsl(0, 0%, 100%)",
+      "--destructive": "hsl(0, 84%, 60%)",
+      "--destructive-foreground": "hsl(0, 0%, 98%)",
+      "--border": "hsl(206, 90%, 82%)",
+      "--input": "hsl(206, 90%, 82%)",
+      "--ring": "hsl(204, 94%, 41%)",
+      "--chart-1": "hsl(201, 100%, 46%)",
+      "--chart-2": "hsl(178, 70%, 45%)",
+      "--chart-3": "hsl(42, 92%, 56%)",
+      "--chart-4": "hsl(217, 91%, 35%)",
+      "--chart-5": "hsl(341, 75%, 51%)",
+      "--sidebar": "hsl(204, 100%, 97%)",
+      "--sidebar-foreground": "hsl(222, 47%, 15%)",
+      "--sidebar-primary": "hsl(204, 94%, 41%)",
+      "--sidebar-primary-foreground": "hsl(0, 0%, 100%)",
+      "--sidebar-accent": "hsl(201, 100%, 46%)",
+      "--sidebar-accent-foreground": "hsl(0, 0%, 100%)",
+      "--sidebar-border": "hsl(206, 90%, 82%)",
+      "--sidebar-ring": "hsl(204, 94%, 41%)",
+      "--theme-color": "#0ea5e9",
+    },
+  },
+  {
+    id: "warm-sunset",
+    name: "웜 선셋",
+    description: "따뜻한 코럴과 베이지로 편안한 분위기 연출",
+    preview: ["#fb7185", "#f97316", "#fee2d5"],
+    values: {
+      "--background": "hsl(25, 86%, 96%)",
+      "--foreground": "hsl(15, 30%, 20%)",
+      "--card": "hsl(0, 0%, 100%)",
+      "--card-foreground": "hsl(15, 30%, 20%)",
+      "--popover": "hsl(0, 0%, 100%)",
+      "--popover-foreground": "hsl(15, 30%, 20%)",
+      "--primary": "hsl(11, 87%, 65%)",
+      "--primary-foreground": "hsl(0, 0%, 100%)",
+      "--secondary": "hsl(20, 90%, 90%)",
+      "--secondary-foreground": "hsl(15, 25%, 25%)",
+      "--muted": "hsl(20, 60%, 88%)",
+      "--muted-foreground": "hsl(15, 20%, 40%)",
+      "--accent": "hsl(24, 94%, 57%)",
+      "--accent-foreground": "hsl(0, 0%, 100%)",
+      "--destructive": "hsl(0, 75%, 55%)",
+      "--destructive-foreground": "hsl(0, 0%, 100%)",
+      "--border": "hsl(20, 60%, 80%)",
+      "--input": "hsl(20, 60%, 80%)",
+      "--ring": "hsl(11, 87%, 65%)",
+      "--chart-1": "hsl(11, 87%, 65%)",
+      "--chart-2": "hsl(32, 95%, 60%)",
+      "--chart-3": "hsl(142, 44%, 57%)",
+      "--chart-4": "hsl(347, 77%, 60%)",
+      "--chart-5": "hsl(199, 89%, 48%)",
+      "--sidebar": "hsl(25, 86%, 96%)",
+      "--sidebar-foreground": "hsl(15, 30%, 20%)",
+      "--sidebar-primary": "hsl(11, 87%, 65%)",
+      "--sidebar-primary-foreground": "hsl(0, 0%, 100%)",
+      "--sidebar-accent": "hsl(24, 94%, 57%)",
+      "--sidebar-accent-foreground": "hsl(0, 0%, 100%)",
+      "--sidebar-border": "hsl(20, 60%, 80%)",
+      "--sidebar-ring": "hsl(11, 87%, 65%)",
+      "--theme-color": "#fb7185",
+    },
+  },
+  {
+    id: "calm-forest",
+    name: "포레스트 그린",
+    description: "자연에서 영감을 받은 싱그러운 그린 테마",
+    preview: ["#34d399", "#0f766e", "#ecfdf5"],
+    values: {
+      "--background": "hsl(156, 72%, 96%)",
+      "--foreground": "hsl(160, 27%, 20%)",
+      "--card": "hsl(0, 0%, 100%)",
+      "--card-foreground": "hsl(160, 27%, 20%)",
+      "--popover": "hsl(0, 0%, 100%)",
+      "--popover-foreground": "hsl(160, 27%, 20%)",
+      "--primary": "hsl(161, 94%, 30%)",
+      "--primary-foreground": "hsl(0, 0%, 100%)",
+      "--secondary": "hsl(152, 65%, 90%)",
+      "--secondary-foreground": "hsl(161, 30%, 20%)",
+      "--muted": "hsl(152, 45%, 88%)",
+      "--muted-foreground": "hsl(161, 24%, 35%)",
+      "--accent": "hsl(161, 94%, 38%)",
+      "--accent-foreground": "hsl(0, 0%, 100%)",
+      "--destructive": "hsl(0, 76%, 54%)",
+      "--destructive-foreground": "hsl(0, 0%, 100%)",
+      "--border": "hsl(151, 52%, 80%)",
+      "--input": "hsl(151, 52%, 80%)",
+      "--ring": "hsl(161, 94%, 38%)",
+      "--chart-1": "hsl(161, 94%, 38%)",
+      "--chart-2": "hsl(152, 65%, 50%)",
+      "--chart-3": "hsl(42, 92%, 56%)",
+      "--chart-4": "hsl(199, 89%, 48%)",
+      "--chart-5": "hsl(347, 77%, 60%)",
+      "--sidebar": "hsl(156, 72%, 96%)",
+      "--sidebar-foreground": "hsl(160, 27%, 20%)",
+      "--sidebar-primary": "hsl(161, 94%, 30%)",
+      "--sidebar-primary-foreground": "hsl(0, 0%, 100%)",
+      "--sidebar-accent": "hsl(161, 94%, 38%)",
+      "--sidebar-accent-foreground": "hsl(0, 0%, 100%)",
+      "--sidebar-border": "hsl(151, 52%, 80%)",
+      "--sidebar-ring": "hsl(161, 94%, 38%)",
+      "--theme-color": "#34d399",
+    },
+  },
+];
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const DEFAULT_THEME = THEMES[0];
+
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [color, setColor] = useState<string>("#3b82f6"); // default primary
+  const [themeId, setThemeId] = useState<string>(DEFAULT_THEME.id);
+
+  const applyTheme = useCallback((theme: ThemeDefinition) => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    Object.entries(theme.values).forEach(([key, value]) => {
+      root.style.setProperty(key, value);
+    });
+    root.setAttribute("data-theme", theme.id);
+  }, []);
 
   useEffect(() => {
     try {
-      const saved = localStorage.getItem("theme-color");
-      if (saved) setColor(saved);
+      const savedId = localStorage.getItem("theme-id");
+      if (savedId) {
+        const storedTheme = THEMES.find((t) => t.id === savedId);
+        if (storedTheme) {
+          setThemeId(storedTheme.id);
+          return;
+        }
+      }
     } catch {}
+    applyTheme(DEFAULT_THEME);
+  }, [applyTheme]);
+
+  const activeTheme = useMemo(() => THEMES.find((theme) => theme.id === themeId) ?? DEFAULT_THEME, [themeId]);
+
+  useEffect(() => {
+    applyTheme(activeTheme);
+  }, [activeTheme, applyTheme]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("theme-id", activeTheme.id);
+    } catch {}
+  }, [activeTheme.id]);
+
+  const setTheme = useCallback((id: string) => {
+    const nextTheme = THEMES.find((theme) => theme.id === id) ?? DEFAULT_THEME;
+    setThemeId(nextTheme.id);
   }, []);
 
-  const update = (c: string) => {
-    setColor(c);
-    try { localStorage.setItem("theme-color", c); } catch {}
-    // also reflect to CSS var
-    const root = document.documentElement;
-    root.style.setProperty("--theme-color", c);
-  };
-
-  // keep CSS variable synced (first render too)
-  useEffect(() => {
-    const root = document.documentElement;
-    root.style.setProperty("--theme-color", color);
-  }, [color]);
-
   return (
-    <ThemeContext.Provider value={{ color, setColor: update }}>
-      <div style={{ ["--theme-color" as any]: color }}>{children}</div>
+    <ThemeContext.Provider value={{ theme: activeTheme, themes: THEMES, setTheme }}>
+      {children}
     </ThemeContext.Provider>
   );
 };

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -38,6 +38,7 @@
   --sidebar-accent-foreground: hsl(0, 0%, 98%);
   --sidebar-border: hsl(214, 32%, 91%);
   --sidebar-ring: hsl(217, 91%, 35%);
+  --theme-color: #3b82f6;
   --font-sans: 'Noto Sans KR', sans-serif;
   --font-serif: Georgia, serif;
   --font-mono: Menlo, monospace;
@@ -86,5 +87,21 @@
   .animate-fade-in.visible {
     opacity: 1;
     transform: translateY(0);
+  }
+
+  .bg-theme {
+    background-color: var(--theme-color);
+  }
+
+  .text-theme {
+    color: var(--theme-color);
+  }
+
+  .border-theme {
+    border-color: var(--theme-color);
+  }
+
+  .ring-theme {
+    --tw-ring-color: var(--theme-color);
   }
 }

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -8,10 +8,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import React from "react";
 import { useTheme } from "@/context/ThemeContext";
+import { cn } from "@/lib/utils";
 
 export default function AdminPage() {
-  const { color, setColor } = useTheme();
-  const [draft, setDraft] = React.useState<string>(color);
+  const { theme, themes, setTheme } = useTheme();
+  const [draft, setDraft] = useState<string>(theme.id);
   const [, navigate] = useLocation();
   const [checked, setChecked] = useState(false);
 
@@ -38,7 +39,16 @@ export default function AdminPage() {
     })();
   }, [navigate]);
 
+  useEffect(() => {
+    setDraft(theme.id);
+  }, [theme.id]);
+
   if (!checked) return null;
+
+  const handleApplyTheme = () => {
+    setTheme(draft);
+    navigate("/");
+  };
 
   const onSubmitChangePassword = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -124,31 +134,58 @@ export default function AdminPage() {
         </DialogContent>
       </Dialog>
 
-      {/* Theme Color Config */}
-      <div className="mt-6 p-4 border rounded-xl bg-white shadow-sm">
-        <h3 className="text-lg font-semibold mb-3">테마 색상 설정</h3>
-        <div className="flex items-center gap-4">
-          <input
-            type="color"
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            className="w-12 h-12 border rounded cursor-pointer"
-            title="테마 색상 선택"
-          />
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-gray-600">현재 선택</span>
-            <span className="px-2 py-1 rounded border" style={{ background: draft, color: '#fff' }}>{draft}</span>
-          </div>
-          <button
-            className="ml-auto px-4 py-2 rounded-lg bg-theme text-white font-medium shadow hover:opacity-90 transition"
-            onClick={() => { setColor(draft); try { localStorage.setItem('theme-color', draft); } catch (e) {}; navigate('/'); }}
-          >
-            테마 적용
-          </button>
+      {/* Theme Config */}
+      <div className="mt-6 rounded-2xl border bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-2">
+          <h3 className="text-lg font-semibold">테마 선택</h3>
+          <p className="text-sm text-muted-foreground">
+            몇 가지 추천 조합 중에서 원하는 분위기를 골라 랜딩 페이지 전체에 적용해보세요.
+          </p>
         </div>
-        <p className="text-xs text-gray-500 mt-2">버튼을 누르면 테마가 적용되고 랜딩 페이지로 이동합니다.</p>
+
+        <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {themes.map((option) => {
+            const selected = option.id === draft;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => setDraft(option.id)}
+                className={cn(
+                  "group flex h-full flex-col overflow-hidden rounded-2xl border text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+                  selected
+                    ? "border-primary shadow-lg ring-2 ring-primary/50"
+                    : "border-border hover:border-primary/40 hover:shadow-md"
+                )}
+              >
+                <div
+                  className="h-24 w-full"
+                  style={{
+                    background: `linear-gradient(135deg, ${option.preview[0]}, ${option.preview[1]}, ${option.preview[2]})`,
+                  }}
+                />
+                <div className="flex flex-1 flex-col gap-2 p-4">
+                  <div className="flex items-center justify-between">
+                    <span className="text-base font-semibold">{option.name}</span>
+                    {selected && <span className="text-xs font-medium text-primary">선택됨</span>}
+                  </div>
+                  <p className="text-sm leading-relaxed text-muted-foreground">{option.description}</p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-</div>
+      <Button
+        size="lg"
+        className="fixed bottom-6 left-6 z-50 shadow-lg"
+        onClick={handleApplyTheme}
+        disabled={draft === theme.id}
+      >
+        {draft === theme.id ? "현재 테마 적용 중" : "테마 적용"}
+      </Button>
+
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the simple color picker with a themed palette selector that previews curated combinations
- expand the theme context to manage full palette definitions and persist the active choice across sessions
- surface the apply action as a floating bottom-left control that updates the landing experience immediately

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4d882a3f8832d8d72cfb07e96aa64