### PR TITLE
Adjust card styling for mobile responsiveness

### DIFF
--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "w-full sm:w-auto rounded-lg border border-border/30 bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- make cards expand to full width on small screens by default
- soften the default card border color for a subtler appearance

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d53a83ae40832daf45ffd4d219c49b