### PR TITLE
Adjust service cards styling on mobile

### DIFF
--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -66,7 +66,7 @@ export function ServicesSection() {
           {services.map((service, index) => (
             <Card
               key={index}
-              className="bg-card overflow-hidden shadow-xl hover:shadow-2xl transition-all animate-fade-in border border-border/50 backdrop-blur-sm"
+              className="overflow-hidden transition-all animate-fade-in rounded-none border-none bg-transparent shadow-none backdrop-blur-0 md:rounded-2xl md:border md:border-border/50 md:bg-card md:shadow-xl md:hover:shadow-2xl md:backdrop-blur-sm"
               data-testid={`card-service-${index}`}
             >
               {/* 카드 전체를 채우는 이미지 */}
@@ -79,8 +79,7 @@ export function ServicesSection() {
                   <img src={service.media as any} alt={service.title} className="w-full h-full object-cover" />
                 )}
               </div>
-
-              <CardContent className="p-6">
+              <CardContent className="px-0 py-6 md:p-6">
                 <h4 className="text-xl font-bold mb-4">{service.title}</h4>
                 <p className="text-muted-foreground">{service.description}</p>
               </CardContent>


### PR DESCRIPTION
## Summary
- remove mobile card styling artifacts from the services section so each item spans the full page width without shadows or borders
- restore desktop-specific styling for the cards at md breakpoint and above to retain their elevated appearance
- adjust card content padding to align with the mobile layout while keeping desktop spacing intact

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d53ca45894832d85cefc154ea59c2d