### PR TITLE
Adjust gallery and services sections for mobile width

### DIFF
--- a/client/src/components/gallery-section.tsx
+++ b/client/src/components/gallery-section.tsx
@@ -71,7 +71,7 @@ export function GallerySection() {
 
   return (
     <section ref={sectionRef} className="py-20 bg-background">
-      <div className="container mx-auto px-4">
+      <div className="mx-auto w-full px-0 md:container md:mx-auto md:px-4">
         <div className="text-center mb-16 animate-fade-in">
           <h3 className="text-3xl md:text-4xl font-bold text-primary mb-4">최첨단 시설</h3>
           <p className="text-lg text-muted-foreground">안전하고 쾌적한 환경에서 제공하는 프리미엄 의료 서비스</p>
@@ -86,16 +86,23 @@ export function GallerySection() {
             >
               <h4 className="text-2xl md:text-3xl font-semibold mb-6">{s.title}</h4>
 
-              <Card className="bg-transparent shadow-none rounded-none md:bg-card md:shadow-sm md:rounded-2xl overflow-hidden">
+              <Card className="bg-transparent shadow-none rounded-none border-none md:bg-card md:shadow-sm md:rounded-2xl overflow-hidden">
                 {String(s.media).toLowerCase().endsWith(".mp4") ? (
-                  <video className="w-full h-[260px] md:h-[360px] object-cover" autoPlay loop muted playsInline preload="metadata">
+                  <video
+                    className="block w-full h-[260px] md:h-[360px] object-cover"
+                    autoPlay
+                    loop
+                    muted
+                    playsInline
+                    preload="metadata"
+                  >
                     <source src={s.media as any} type="video/mp4" />
                   </video>
                 ) : (
                   <img
                     src={s.media as any}
                     alt={s.title}
-                    className="w-full h-[260px] md:h-[360px] object-cover"
+                    className="block w-full h-[260px] md:h-[360px] object-cover"
                     loading="lazy"
                   />
                 )}

--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -52,7 +52,7 @@ export function ServicesSection() {
       className="py-20 bg-secondary"
       data-testid="section-services"
     >
-      <div className="container mx-auto px-4">
+      <div className="mx-auto w-full px-0 md:container md:mx-auto md:px-4">
         <div className="text-center mb-16 animate-fade-in">
           <h3 className="text-3xl md:text-4xl font-bold text-primary mb-4">
             전문 진료 분야
@@ -66,17 +66,24 @@ export function ServicesSection() {
           {services.map((service, index) => (
             <Card
               key={index}
-              className="overflow-hidden transition-all animate-fade-in rounded-none border-none bg-transparent shadow-none backdrop-blur-0 md:rounded-2xl md:border md:border-border/50 md:bg-card md:shadow-xl md:hover:shadow-2xl md:backdrop-blur-sm"
+              className="overflow-hidden transition-all animate-fade-in rounded-none border-none bg-transparent shadow-none backdrop-blur-0 md:rounded-2xl md:bg-card md:shadow-xl md:hover:shadow-2xl md:backdrop-blur-sm"
               data-testid={`card-service-${index}`}
             >
               {/* 카드 전체를 채우는 이미지 */}
               <div className="w-full h-48 md:h-64">
                 {String(service.media).toLowerCase().endsWith(".mp4") ? (
-                  <video className="w-full h-full object-cover" autoPlay loop muted playsInline preload="metadata">
+                  <video
+                    className="block w-full h-full object-cover"
+                    autoPlay
+                    loop
+                    muted
+                    playsInline
+                    preload="metadata"
+                  >
                     <source src={service.media as any} type="video/mp4" />
                   </video>
                 ) : (
-                  <img src={service.media as any} alt={service.title} className="w-full h-full object-cover" />
+                  <img src={service.media as any} alt={service.title} className="block w-full h-full object-cover" />
                 )}
               </div>
               <CardContent className="px-0 py-6 md:p-6">


### PR DESCRIPTION
## Summary
- remove default card borders in the gallery and services sections so cards stay frameless at every breakpoint
- expand both sections to span the full viewport width on mobile while keeping the desktop layout intact
- ensure embedded videos and fallback images render as block-level elements to fill the available width without gutters

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5404ebb24832d9ac9584e9bfa8d34