### PR TITLE
Enhance mobile spacing and stabilize video previews

### DIFF
--- a/client/src/components/gallery-section.tsx
+++ b/client/src/components/gallery-section.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
+import { VideoWithPreview } from "@/components/video-with-preview";
 import { useEffect, useRef } from "react";
 import waiting_vid from "@assets/waiting.mp4";
 import talk_vid from "@assets/talk.mp4";
@@ -88,16 +89,11 @@ export function GallerySection() {
 
               <Card className="bg-transparent shadow-none rounded-none border-none md:bg-card md:shadow-sm md:rounded-2xl overflow-hidden">
                 {String(s.media).toLowerCase().endsWith(".mp4") ? (
-                  <video
-                    className="block w-full h-[260px] md:h-[360px] object-cover"
-                    autoPlay
-                    loop
-                    muted
-                    playsInline
-                    preload="metadata"
-                  >
-                    <source src={s.media as any} type="video/mp4" />
-                  </video>
+                  <VideoWithPreview
+                    src={s.media as string}
+                    className="h-[260px] md:h-[360px]"
+                    preload="auto"
+                  />
                 ) : (
                   <img
                     src={s.media as any}
@@ -106,7 +102,7 @@ export function GallerySection() {
                     loading="lazy"
                   />
                 )}
-                <CardContent className="p-0 pt-6 md:p-8">
+                <CardContent className="px-6 pb-6 pt-6 md:p-8">
                   <p className="text-base md:text-lg leading-relaxed text-muted-foreground">
                     {s.long}
                   </p>

--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
+import { VideoWithPreview } from "@/components/video-with-preview";
 import { useEffect, useRef } from "react";
 import lift_img from "@assets/lift.mp4";
 import anti_img from "@assets/anti.mp4";
@@ -72,21 +73,12 @@ export function ServicesSection() {
               {/* 카드 전체를 채우는 이미지 */}
               <div className="w-full h-48 md:h-64">
                 {String(service.media).toLowerCase().endsWith(".mp4") ? (
-                  <video
-                    className="block w-full h-full object-cover"
-                    autoPlay
-                    loop
-                    muted
-                    playsInline
-                    preload="metadata"
-                  >
-                    <source src={service.media as any} type="video/mp4" />
-                  </video>
+                  <VideoWithPreview src={service.media as string} className="h-full" preload="auto" />
                 ) : (
                   <img src={service.media as any} alt={service.title} className="block w-full h-full object-cover" />
                 )}
               </div>
-              <CardContent className="px-0 py-6 md:p-6">
+              <CardContent className="px-6 py-6 md:p-6">
                 <h4 className="text-xl font-bold mb-4">{service.title}</h4>
                 <p className="text-muted-foreground">{service.description}</p>
               </CardContent>

--- a/client/src/components/video-with-preview.tsx
+++ b/client/src/components/video-with-preview.tsx
@@ -1,0 +1,186 @@
+import { cn } from "@/lib/utils";
+import {
+  ComponentPropsWithoutRef,
+  type SyntheticEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+function captureFrame(video: HTMLVideoElement) {
+  if (!video.videoWidth || !video.videoHeight) return undefined;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  const context = canvas.getContext("2d");
+  if (!context) return undefined;
+
+  context.drawImage(video, 0, 0, canvas.width, canvas.height);
+  try {
+    return canvas.toDataURL("image/jpeg", 0.92);
+  } catch (error) {
+    console.warn("Failed to capture video frame", error);
+    return undefined;
+  }
+}
+
+type VideoWithPreviewProps = Omit<ComponentPropsWithoutRef<"video">, "children" | "poster"> & {
+  /**
+   * Video source url.
+   */
+  src: string;
+  /**
+   * Mime type for the source element. Defaults to `video/mp4`.
+   */
+  type?: string;
+  /**
+   * Optional alt text for the generated preview image.
+   */
+  previewAlt?: string;
+};
+
+/**
+ * Video component that keeps a preview frame visible when the video is waiting or stalled.
+ */
+export function VideoWithPreview({
+  className,
+  src,
+  type = "video/mp4",
+  previewAlt = "Video preview",
+  autoPlay = true,
+  loop = true,
+  muted = true,
+  playsInline = true,
+  onLoadedData,
+  onCanPlay,
+  onPlaying,
+  onWaiting,
+  onStalled,
+  onError,
+  ...videoProps
+}: VideoWithPreviewProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [preview, setPreview] = useState<string>();
+  const [showPreview, setShowPreview] = useState(true);
+
+  // Reset preview when the source changes.
+  useEffect(() => {
+    setPreview(undefined);
+    setShowPreview(true);
+  }, [src]);
+
+  useEffect(() => {
+    const videoElement = videoRef.current;
+    if (!videoElement) return;
+
+    const ensurePreview = () => {
+      if (!preview) {
+        const frame = captureFrame(videoElement);
+        if (frame) {
+          setPreview(frame);
+        }
+      }
+    };
+
+    const toSynthetic = (event: Event) => event as unknown as SyntheticEvent<HTMLVideoElement, Event>;
+
+    const handleLoadedData = (event: Event) => {
+      ensurePreview();
+      onLoadedData?.(toSynthetic(event));
+    };
+
+    const handleCanPlay = (event: Event) => {
+      ensurePreview();
+      setShowPreview(videoElement.paused);
+      onCanPlay?.(toSynthetic(event));
+    };
+
+    const handlePlaying = (event: Event) => {
+      setShowPreview(false);
+      onPlaying?.(toSynthetic(event));
+    };
+
+    const handleWaiting = (event: Event) => {
+      ensurePreview();
+      setShowPreview(true);
+      onWaiting?.(toSynthetic(event));
+    };
+
+    const handleStalled = (event: Event) => {
+      ensurePreview();
+      setShowPreview(true);
+      onStalled?.(toSynthetic(event));
+    };
+
+    const handleError = (event: Event) => {
+      ensurePreview();
+      setShowPreview(true);
+      onError?.(toSynthetic(event));
+    };
+
+    videoElement.addEventListener("loadeddata", handleLoadedData);
+    videoElement.addEventListener("canplay", handleCanPlay);
+    videoElement.addEventListener("playing", handlePlaying);
+    videoElement.addEventListener("waiting", handleWaiting);
+    videoElement.addEventListener("stalled", handleStalled);
+    videoElement.addEventListener("error", handleError);
+
+    return () => {
+      videoElement.removeEventListener("loadeddata", handleLoadedData);
+      videoElement.removeEventListener("canplay", handleCanPlay);
+      videoElement.removeEventListener("playing", handlePlaying);
+      videoElement.removeEventListener("waiting", handleWaiting);
+      videoElement.removeEventListener("stalled", handleStalled);
+      videoElement.removeEventListener("error", handleError);
+    };
+  }, [onCanPlay, onError, onLoadedData, onPlaying, onStalled, onWaiting, preview, src]);
+
+  useEffect(() => {
+    const videoElement = videoRef.current;
+    if (!videoElement) return;
+
+    if (autoPlay) {
+      const playPromise = videoElement.play();
+      if (playPromise?.catch) {
+        playPromise.catch(() => {
+          // Keep the preview visible when autoplay is not allowed.
+          setShowPreview(true);
+        });
+      }
+    }
+  }, [autoPlay, src]);
+
+  const previewImage = useMemo(() => {
+    if (!preview) return null;
+    return (
+      <img
+        aria-hidden
+        alt={previewAlt}
+        src={preview}
+        className={cn(
+          "pointer-events-none absolute inset-0 h-full w-full object-cover transition-opacity duration-300",
+          showPreview ? "opacity-100" : "opacity-0"
+        )}
+      />
+    );
+  }, [preview, previewAlt, showPreview]);
+
+  return (
+    <div className="relative h-full w-full overflow-hidden">
+      {previewImage}
+      <video
+        ref={videoRef}
+        className={cn("relative z-10 h-full w-full object-cover", className)}
+        muted={muted}
+        loop={loop}
+        playsInline={playsInline}
+        autoPlay={autoPlay}
+        {...videoProps}
+      >
+        <source src={src} type={type} />
+      </video>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `VideoWithPreview` component that captures a poster frame and shows it whenever playback stalls
- update GallerySection and ServicesSection to use the new video component and apply extra mobile padding around textual content

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5432196e4832dbcb66455adf82c53