### PR TITLE
Center titles in gallery and services sections

### DIFF
--- a/client/src/components/gallery-section.tsx
+++ b/client/src/components/gallery-section.tsx
@@ -85,7 +85,9 @@ export function GallerySection() {
               key={idx}
               className="animate-fade-in"
             >
-              <h4 className="text-2xl md:text-3xl font-semibold mb-6">{s.title}</h4>
+              <h4 className="text-2xl md:text-3xl font-semibold mb-6 text-center">
+                {s.title}
+              </h4>
 
               <Card className="bg-transparent shadow-none rounded-none border-none md:bg-card md:shadow-sm md:rounded-2xl overflow-hidden">
                 {String(s.media).toLowerCase().endsWith(".mp4") ? (

--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -79,7 +79,7 @@ export function ServicesSection() {
                 )}
               </div>
               <CardContent className="px-6 py-6 md:p-6">
-                <h4 className="text-xl font-bold mb-4">{service.title}</h4>
+                <h4 className="text-xl font-bold mb-4 text-center">{service.title}</h4>
                 <p className="text-muted-foreground">{service.description}</p>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- center the subsection titles in the gallery section for consistent alignment
- align the service card headings to the center for visual consistency

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d547fc1f14832dbbec68904930dd41