### PR TITLE
Adjust hero section background height

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -9,7 +9,7 @@ interface HeroSectionProps {
 
 export function HeroSection({ onKakaoClick }: HeroSectionProps) {
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
+    <section className="relative min-h-[50vh] flex items-center justify-center overflow-hidden">
       {/* Background Image */}
       <div className="absolute inset-0">
         <VideoWithPreview


### PR DESCRIPTION
## Summary
- reduce the hero section's minimum height so the clinic video and preview image appear half as tall

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d551affef4832dbe7bb46db241f837