### PR TITLE
Enhance hero video overlay and mobile logo scaling

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -8,8 +8,11 @@ interface HeroSectionProps {
 }
 
 export function HeroSection({ onKakaoClick }: HeroSectionProps) {
+  const taglineTitle = "서울 안티에이징 피부과";
+  const taglineSubtitle = "동안을 디자인하는 프리미엄 안티에이징 클리닉";
+
   return (
-    <section className="relative min-h-[50vh] flex items-center justify-center overflow-hidden">
+    <section className="relative min-h-[50vh] flex items-center justify-center overflow-hidden pb-32 md:pb-40">
       {/* Background Image */}
       <div className="absolute inset-0">
         <VideoWithPreview
@@ -22,6 +25,7 @@ export function HeroSection({ onKakaoClick }: HeroSectionProps) {
           aria-hidden
         />
         <div className="absolute inset-0 bg-primary/80"></div>
+        <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-b from-transparent via-primary/60 to-slate-50 dark:to-slate-950"></div>
       </div>
 
       {/* Content */}
@@ -64,6 +68,16 @@ export function HeroSection({ onKakaoClick }: HeroSectionProps) {
             <MessageSquare className="w-5 h-5 mr-2" />
             카카오톡 상담
           </Button>
+        </div>
+      </div>
+
+      {/* Tagline Overlay */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20">
+        <div className="mx-auto max-w-3xl px-4 pb-6 md:pb-10">
+          <div className="rounded-2xl border border-white/30 bg-white/90 p-6 shadow-xl backdrop-blur-sm dark:border-white/20 dark:bg-slate-900/85">
+            <h3 className="text-2xl font-bold text-primary md:text-3xl">{taglineTitle}</h3>
+            <p className="mt-2 text-base text-slate-600 md:text-lg dark:text-slate-200">{taglineSubtitle}</p>
+          </div>
         </div>
       </div>
     </section>

--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -59,10 +59,10 @@ export function ServicesSection() {
       <div className="mx-auto w-full px-0 md:container md:mx-auto md:px-4">
         <div className="text-center mb-16 animate-fade-in">
           <h3 className="text-3xl md:text-4xl font-bold text-primary mb-4">
-            전문 진료 분야
+            서울 안티에이징 피부과
           </h3>
           <p className="text-lg text-muted-foreground">
-            최고의 전문성으로 제공하는 맞춤형 피부 치료
+            동안을 디자인하는 프리미엄 안티에이징 클리닉
           </p>
         </div>
 

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -74,7 +74,13 @@ export default function Landing() {
       {/* Fixed Header */}
       <header className="fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-md border-b border-border shadow-sm">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="h-16 md:h-20 flex items-center justify-center"><img src={logoImage} alt="서울 안티에이징 피부과 의원" className="max-h-full object-contain mx-auto" /></div>
+          <div className="h-16 md:h-20 flex items-center justify-center">
+            <img
+              src={logoImage}
+              alt="서울 안티에이징 피부과 의원"
+              className="h-full w-auto max-w-none object-contain mx-auto"
+            />
+          </div>
           <div className="flex items-center space-x-4">
 
             <div className="hidden md:flex items-center space-x-2 text-theme font-medium">


### PR DESCRIPTION
## Summary
- enlarge the fixed header logo on mobile by letting the image fill the existing container height
- add a bottom gradient and tagline overlay to the hero video for a softer blend into the page background
- reuse the new clinic tagline inside the services section introduction copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f5279674832d90faf964c13bef70