### PR TITLE
feat: enlarge mobile logo display

### DIFF
--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -78,7 +78,7 @@ export default function Landing() {
             <img
               src={logoImage}
               alt="서울 안티에이징 피부과 의원"
-              className="h-full w-auto max-w-none object-contain mx-auto"
+              className="h-full w-auto max-w-none object-contain mx-auto scale-150 md:scale-100"
             />
           </div>
           <div className="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
- increase the mobile logo scale on the landing page so it appears 1.5x larger without changing the header height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d628d40468832d929f08db9c5673af