### PR TITLE
Center align logo on mobile header

### DIFF
--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -73,7 +73,7 @@ export default function Landing() {
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-rose-50 to-indigo-50 dark:from-slate-900 dark:via-slate-800 dark:to-indigo-900">
       {/* Fixed Header */}
       <header className="fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-md border-b border-border shadow-sm">
-        <div className="container mx-auto px-4 py-2 flex items-center justify-between">
+        <div className="container mx-auto px-4 py-2 flex items-center justify-center md:justify-between">
           <div className="h-16 md:h-20 flex items-center justify-center">
             <img
               src={logoImage}
@@ -81,7 +81,7 @@ export default function Landing() {
               className="h-full w-auto max-w-none object-contain mx-auto scale-150 md:scale-100"
             />
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="hidden md:flex items-center space-x-4">
 
             <div className="hidden md:flex items-center space-x-2 text-theme font-medium">
               <Phone className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- center the landing header logo on mobile viewports
- hide the desktop-only contact controls on smaller screens to avoid layout gaps

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d62fd975c0832dbc3b5a4de0620397