### PR TITLE
히어로 섹션을 헤더 아래로 겹치도록 조정

### DIFF
--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -102,7 +102,9 @@ export default function Landing() {
 
       {/* Main Content */}
       <main className="pt-20">
-        <HeroSection onKakaoClick={openKakaoTalk} />
+        <div className="-mt-20">
+          <HeroSection onKakaoClick={openKakaoTalk} />
+        </div>
         <ServicesSection />
         <GallerySection />
         {/* <AppointmentBooking /> */}


### PR DESCRIPTION
## Summary
- 랜딩 페이지의 히어로 섹션을 음수 마진으로 감싸 clinic.jpg/mp4 미디어가 화면 최상단에서 노출되도록 조정했습니다.

## Testing
- 테스트 미실행 (DATABASE_URL 환경 변수 미설정으로 서버 구동 불가)


------
https://chatgpt.com/codex/tasks/task_e_68d632fdaa2c832dbf173f52d21ba7b0