### PR TITLE
Allow dev server to run without database configuration

### DIFF
--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -78,7 +78,7 @@ export default function Landing() {
             <img
               src={logoImage}
               alt="서울 안티에이징 피부과 의원"
-              className="h-full w-auto max-w-none object-contain mx-auto scale-150 md:scale-100"
+              className="h-full w-[90vw] max-w-[90vw] object-contain mx-auto md:w-auto md:max-w-none"
             />
           </div>
           <div className="hidden md:flex items-center space-x-4">

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -12,23 +12,24 @@ import {
   type Appointment,
   type InsertAppointment,
 } from "@shared/schema";
-import { db } from "./db";
 import { eq, desc, and, gte, lte } from "drizzle-orm";
+import { getDatabaseClient } from "./db";
+import { randomUUID } from "node:crypto";
 
 export interface IStorage {
   // User operations (required for Replit Auth)
   getUser(id: string): Promise<User | undefined>;
   upsertUser(user: UpsertUser): Promise<User>;
-  
+
   // Inquiry operations
   createInquiry(inquiry: InsertInquiry): Promise<Inquiry>;
   getAllInquiries(): Promise<Inquiry[]>;
   updateInquiryStatus(id: string, status: string): Promise<void>;
-  
+
   // Service type operations
   getAllServiceTypes(): Promise<ServiceType[]>;
   createServiceType(serviceType: InsertServiceType): Promise<ServiceType>;
-  
+
   // Appointment operations
   createAppointment(appointment: InsertAppointment): Promise<Appointment>;
   getAllAppointments(): Promise<Appointment[]>;
@@ -36,15 +37,19 @@ export interface IStorage {
   updateAppointmentStatus(id: string, status: string): Promise<void>;
 }
 
+type DatabaseClient = NonNullable<ReturnType<typeof getDatabaseClient>>;
+
 export class DatabaseStorage implements IStorage {
+  constructor(private readonly db: DatabaseClient) {}
+
   // User operations
   async getUser(id: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.id, id));
+    const [user] = await this.db.select().from(users).where(eq(users.id, id));
     return user;
   }
 
   async upsertUser(userData: UpsertUser): Promise<User> {
-    const [user] = await db
+    const [user] = await this.db
       .insert(users)
       .values(userData)
       .onConflictDoUpdate({
@@ -60,7 +65,7 @@ export class DatabaseStorage implements IStorage {
 
   // Inquiry operations
   async createInquiry(inquiryData: InsertInquiry): Promise<Inquiry> {
-    const [inquiry] = await db
+    const [inquiry] = await this.db
       .insert(inquiries)
       .values(inquiryData)
       .returning();
@@ -68,14 +73,14 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getAllInquiries(): Promise<Inquiry[]> {
-    return await db
+    return await this.db
       .select()
       .from(inquiries)
       .orderBy(desc(inquiries.createdAt));
   }
 
   async updateInquiryStatus(id: string, status: string): Promise<void> {
-    await db
+    await this.db
       .update(inquiries)
       .set({ status })
       .where(eq(inquiries.id, id));
@@ -83,7 +88,7 @@ export class DatabaseStorage implements IStorage {
 
   // Service type operations
   async getAllServiceTypes(): Promise<ServiceType[]> {
-    return await db
+    return await this.db
       .select()
       .from(serviceTypes)
       .where(eq(serviceTypes.isActive, "active"))
@@ -91,7 +96,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createServiceType(serviceTypeData: InsertServiceType): Promise<ServiceType> {
-    const [serviceType] = await db
+    const [serviceType] = await this.db
       .insert(serviceTypes)
       .values(serviceTypeData)
       .returning();
@@ -100,7 +105,7 @@ export class DatabaseStorage implements IStorage {
 
   // Appointment operations
   async createAppointment(appointmentData: InsertAppointment): Promise<Appointment> {
-    const [appointment] = await db
+    const [appointment] = await this.db
       .insert(appointments)
       .values(appointmentData)
       .returning();
@@ -108,7 +113,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getAllAppointments(): Promise<Appointment[]> {
-    return await db
+    return await this.db
       .select()
       .from(appointments)
       .orderBy(desc(appointments.appointmentDate));
@@ -118,8 +123,8 @@ export class DatabaseStorage implements IStorage {
     const startOfDay = new Date(date);
     const endOfDay = new Date(date);
     endOfDay.setHours(23, 59, 59, 999);
-    
-    return await db
+
+    return await this.db
       .select()
       .from(appointments)
       .where(
@@ -132,11 +137,157 @@ export class DatabaseStorage implements IStorage {
   }
 
   async updateAppointmentStatus(id: string, status: string): Promise<void> {
-    await db
+    await this.db
       .update(appointments)
       .set({ status, updatedAt: new Date() })
       .where(eq(appointments.id, id));
   }
 }
 
-export const storage = new DatabaseStorage();
+class InMemoryStorage implements IStorage {
+  private users: User[] = [];
+  private inquiries: Inquiry[] = [];
+  private serviceTypes: ServiceType[] = [];
+  private appointments: Appointment[] = [];
+
+  async getUser(id: string): Promise<User | undefined> {
+    return this.users.find((user) => user.id === id);
+  }
+
+  async upsertUser(userData: UpsertUser): Promise<User> {
+    const now = new Date();
+    const existingIndex = userData.id
+      ? this.users.findIndex((user) => user.id === userData.id)
+      : -1;
+
+    if (existingIndex >= 0) {
+      const updatedUser: User = {
+        ...this.users[existingIndex],
+        ...userData,
+        updatedAt: now,
+      };
+      this.users[existingIndex] = updatedUser;
+      return updatedUser;
+    }
+
+    const newUser: User = {
+      id: userData.id ?? randomUUID(),
+      email: userData.email ?? null,
+      firstName: userData.firstName ?? null,
+      lastName: userData.lastName ?? null,
+      profileImageUrl: userData.profileImageUrl ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.users.push(newUser);
+    return newUser;
+  }
+
+  async createInquiry(inquiryData: InsertInquiry): Promise<Inquiry> {
+    const now = new Date();
+    const inquiry: Inquiry = {
+      id: randomUUID(),
+      name: inquiryData.name,
+      phone: inquiryData.phone,
+      inquiry: inquiryData.inquiry,
+      createdAt: now,
+      status: "new",
+    };
+    this.inquiries.unshift(inquiry);
+    return inquiry;
+  }
+
+  async getAllInquiries(): Promise<Inquiry[]> {
+    return [...this.inquiries];
+  }
+
+  async updateInquiryStatus(id: string, status: string): Promise<void> {
+    const inquiry = this.inquiries.find((item) => item.id === id);
+    if (inquiry) {
+      inquiry.status = status;
+    }
+  }
+
+  async getAllServiceTypes(): Promise<ServiceType[]> {
+    return this.serviceTypes
+      .filter((serviceType) => serviceType.isActive === "active")
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async createServiceType(serviceTypeData: InsertServiceType): Promise<ServiceType> {
+    const now = new Date();
+    const serviceType: ServiceType = {
+      id: randomUUID(),
+      name: serviceTypeData.name,
+      description: serviceTypeData.description ?? null,
+      duration: serviceTypeData.duration,
+      price: serviceTypeData.price ?? null,
+      isActive: "active",
+      createdAt: now,
+    };
+    this.serviceTypes.push(serviceType);
+    return serviceType;
+  }
+
+  async createAppointment(appointmentData: InsertAppointment): Promise<Appointment> {
+    const now = new Date();
+    const rawAppointmentDate = appointmentData.appointmentDate;
+    const appointmentDate =
+      rawAppointmentDate instanceof Date
+        ? rawAppointmentDate
+        : new Date(rawAppointmentDate as unknown as string);
+    const appointment: Appointment = {
+      id: randomUUID(),
+      name: appointmentData.name,
+      phone: appointmentData.phone,
+      email: appointmentData.email ?? null,
+      serviceTypeId: appointmentData.serviceTypeId ?? null,
+      appointmentDate,
+      notes: appointmentData.notes ?? null,
+      address: appointmentData.address ?? null,
+      latitude: appointmentData.latitude ?? null,
+      longitude: appointmentData.longitude ?? null,
+      status: "pending",
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.appointments.push(appointment);
+    return appointment;
+  }
+
+  async getAllAppointments(): Promise<Appointment[]> {
+    return [...this.appointments].sort(
+      (a, b) => b.appointmentDate.getTime() - a.appointmentDate.getTime()
+    );
+  }
+
+  async getAppointmentsByDate(date: string): Promise<Appointment[]> {
+    const startOfDay = new Date(date);
+    startOfDay.setHours(0, 0, 0, 0);
+    const endOfDay = new Date(date);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    return this.appointments.filter((appointment) => {
+      const time = appointment.appointmentDate.getTime();
+      return time >= startOfDay.getTime() && time <= endOfDay.getTime();
+    });
+  }
+
+  async updateAppointmentStatus(id: string, status: string): Promise<void> {
+    const appointment = this.appointments.find((item) => item.id === id);
+    if (appointment) {
+      appointment.status = status;
+      appointment.updatedAt = new Date();
+    }
+  }
+}
+
+const databaseClient = getDatabaseClient();
+
+if (!databaseClient) {
+  console.warn("DATABASE_URL이 설정되지 않아 인메모리 스토리지를 사용합니다.");
+}
+
+export const storage: IStorage = databaseClient
+  ? new DatabaseStorage(databaseClient)
+  : new InMemoryStorage();


### PR DESCRIPTION
## Summary
- adjust the landing page header logo so that it uses 90% of the viewport width on mobile while keeping the desktop sizing unchanged
- fall back to an in-memory storage implementation when DATABASE_URL is not set so the development server can run without provisioning a database

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68d63f66f0c8832db4ed73d480c0e470