### PR TITLE
Align desktop layout with mobile for services and gallery sections

### DIFF
--- a/client/src/components/gallery-section.tsx
+++ b/client/src/components/gallery-section.tsx
@@ -72,9 +72,9 @@ export function GallerySection() {
 
   return (
     <section ref={sectionRef} className="py-20 bg-background">
-      <div className="mx-auto w-full px-0 md:container md:mx-auto md:px-4">
+      <div className="mx-auto w-full px-0">
         <div className="text-center mb-16 animate-fade-in">
-          <h3 className="text-3xl md:text-4xl font-bold text-primary mb-4">최첨단 시설</h3>
+          <h3 className="text-3xl font-bold text-primary mb-4">최첨단 시설</h3>
           <p className="text-lg text-muted-foreground">안전하고 쾌적한 환경에서 제공하는 프리미엄 의료 서비스</p>
         </div>
 
@@ -85,27 +85,27 @@ export function GallerySection() {
               key={idx}
               className="animate-fade-in"
             >
-              <h4 className="text-2xl md:text-3xl font-semibold mb-6 text-center">
+              <h4 className="text-2xl font-semibold mb-6 text-center">
                 {s.title}
               </h4>
 
-              <Card className="bg-transparent shadow-none rounded-none border-none md:bg-card md:shadow-sm md:rounded-2xl overflow-hidden">
+              <Card className="bg-transparent shadow-none rounded-none border-none overflow-hidden">
                 {String(s.media).toLowerCase().endsWith(".mp4") ? (
                   <VideoWithPreview
                     src={s.media as string}
-                    className="h-[260px] md:h-[360px]"
+                    className="h-[260px]"
                     preload="auto"
                   />
                 ) : (
                   <img
                     src={s.media as any}
                     alt={s.title}
-                    className="block w-full h-[260px] md:h-[360px] object-cover"
+                    className="block w-full h-[260px] object-cover"
                     loading="lazy"
                   />
                 )}
-                <CardContent className="px-6 pb-6 pt-6 md:p-8">
-                  <p className="text-base md:text-lg leading-relaxed text-muted-foreground">
+                <CardContent className="px-6 pb-6 pt-6">
+                  <p className="text-base leading-relaxed text-muted-foreground">
                     {s.long}
                   </p>
                 </CardContent>

--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -56,24 +56,24 @@ export function ServicesSection() {
       className="py-20 bg-secondary"
       data-testid="section-services"
     >
-      <div className="mx-auto w-full px-0 md:container md:mx-auto md:px-4">
+      <div className="mx-auto w-full px-0">
 
-        <div className="grid md:grid-cols-3 gap-8">
+        <div className="grid gap-8">
           {services.map((service, index) => (
             <Card
               key={index}
-              className="overflow-hidden transition-all animate-fade-in rounded-none border-none bg-transparent shadow-none backdrop-blur-0 md:rounded-2xl md:bg-card md:shadow-xl md:hover:shadow-2xl md:backdrop-blur-sm"
+              className="overflow-hidden transition-all animate-fade-in rounded-none border-none bg-transparent shadow-none backdrop-blur-0"
               data-testid={`card-service-${index}`}
             >
               {/* 카드 전체를 채우는 이미지 */}
-              <div className="w-full h-48 md:h-64">
+              <div className="w-full h-48">
                 {String(service.media).toLowerCase().endsWith(".mp4") ? (
                   <VideoWithPreview src={service.media as string} className="h-full" preload="auto" />
                 ) : (
                   <img src={service.media as any} alt={service.title} className="block w-full h-full object-cover" />
                 )}
               </div>
-              <CardContent className="px-6 py-6 md:p-6">
+              <CardContent className="px-6 py-6">
                 <h4 className="text-xl font-bold mb-4 text-center">{service.title}</h4>
                 <p className="text-muted-foreground">{service.description}</p>
               </CardContent>


### PR DESCRIPTION
## Summary
- remove desktop-specific grid and styling overrides from the services section so desktop follows the mobile single-column presentation
- align the gallery section layout and typography across breakpoints by dropping desktop-only styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d755d89138832da1d99fdffea2c0f5