### PR TITLE
Implement looping responsive services carousel

### DIFF
--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -1,26 +1,53 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { VideoWithPreview } from "@/components/video-with-preview";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import lift_img from "@assets/lift.mp4";
 import anti_img from "@assets/anti.mp4";
 import re_img from "@assets/re.mp4";
 
 export function ServicesSection() {
   const sectionRef = useRef<HTMLElement>(null);
-  const [currentIndex, setCurrentIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
   const startXRef = useRef<number | null>(null);
   const pointerIdRef = useRef<number | null>(null);
+  const [displayIndex, setDisplayIndex] = useState(1);
+  const [isTransitionEnabled, setIsTransitionEnabled] = useState(true);
 
-  const goToIndex = (index: number) => {
-    setCurrentIndex((prev) => {
-      if (index < 0) {
-        return 0;
-      }
-      if (index >= services.length) {
-        return services.length - 1;
-      }
-      return index;
-    });
+  const services = useMemo(
+    () => [
+      {
+        media: anti_img,
+        title: "안티에이징",
+        description:
+          "깊은 주름과 잔주름을 동시에 케어하며, 피부 속 콜라겐 생성을 활성화하는 맞춤형 프로그램입니다. 혈류 순환을 도와 탄력을 되찾게 하고, 생활 습관에 맞춘 홈케어 솔루션까지 제안해 장기적인 젊음을 유지하도록 돕습니다.",
+      },
+      {
+        media: re_img,
+        title: "피부재생",
+        description:
+          "여드름 흉터부터 외부 자극으로 인한 민감성 피부까지 단계별로 회복시키는 집중 관리입니다. 최신 재생 레이저와 성장인자 치료를 병행해 피부 장벽을 강화하고, 맞춤형 재생 크림으로 회복 속도를 높여드립니다.",
+      },
+      {
+        media: lift_img,
+        title: "피부 리프팅",
+        description:
+          "탄력이 떨어진 부위를 정밀하게 타겟팅해 처짐을 개선하고 윤곽 라인을 정돈하는 리프팅 솔루션입니다. 고강도 초음파 에너지와 콜라겐 부스터를 함께 적용해 시술 직후 탄력 변화를 느낄 수 있도록 설계되었습니다.",
+      },
+    ],
+    []
+  );
+
+  const serviceCount = services.length;
+
+  const goToNext = () => {
+    if (serviceCount === 0) return;
+    setDisplayIndex((prev) => prev + 1);
+  };
+
+  const goToPrev = () => {
+    if (serviceCount === 0) return;
+    setDisplayIndex((prev) => prev - 1);
   };
 
   const handlePointerDown = (clientX: number) => {
@@ -34,13 +61,37 @@ export function ServicesSection() {
     const threshold = 50;
 
     if (deltaX <= -threshold) {
-      goToIndex(currentIndex + 1);
+      goToNext();
     } else if (deltaX >= threshold) {
-      goToIndex(currentIndex - 1);
+      goToPrev();
+    } else {
+      const midpoint = (containerRef.current?.offsetWidth ?? window.innerWidth) / 2;
+      if (clientX > midpoint) {
+        goToNext();
+      } else {
+        goToPrev();
+      }
     }
 
     startXRef.current = null;
   };
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.contentRect) {
+          setContainerWidth(entry.contentRect.width);
+        }
+      }
+    });
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -63,26 +114,56 @@ export function ServicesSection() {
     return () => observer.disconnect();
   }, []);
 
-  const services = [
-    {
-      media: anti_img,
-      title: "안티에이징",
-      description:
-        "깊은 주름과 잔주름을 동시에 케어하며, 피부 속 콜라겐 생성을 활성화하는 맞춤형 프로그램입니다. 혈류 순환을 도와 탄력을 되찾게 하고, 생활 습관에 맞춘 홈케어 솔루션까지 제안해 장기적인 젊음을 유지하도록 돕습니다.",
-    },
-    {
-      media: re_img,
-      title: "피부재생",
-      description:
-        "여드름 흉터부터 외부 자극으로 인한 민감성 피부까지 단계별로 회복시키는 집중 관리입니다. 최신 재생 레이저와 성장인자 치료를 병행해 피부 장벽을 강화하고, 맞춤형 재생 크림으로 회복 속도를 높여드립니다.",
-    },
-    {
-      media: lift_img,
-      title: "피부 리프팅",
-      description:
-        "탄력이 떨어진 부위를 정밀하게 타겟팅해 처짐을 개선하고 윤곽 라인을 정돈하는 리프팅 솔루션입니다. 고강도 초음파 에너지와 콜라겐 부스터를 함께 적용해 시술 직후 탄력 변화를 느낄 수 있도록 설계되었습니다.",
-    },
-  ];
+  const cardWidth = useMemo(() => {
+    if (containerWidth === 0) return 0;
+    return containerWidth * 0.8;
+  }, [containerWidth]);
+
+  const gap = useMemo(() => {
+    if (containerWidth === 0) return 0;
+    return containerWidth * 0.04;
+  }, [containerWidth]);
+
+  const sidePadding = useMemo(() => {
+    if (containerWidth === 0 || cardWidth === 0) return 0;
+    return (containerWidth - cardWidth) / 2;
+  }, [cardWidth, containerWidth]);
+
+  const extendedServices = useMemo(() => {
+    if (serviceCount === 0) return [] as typeof services;
+    const first = services[0];
+    const last = services[serviceCount - 1];
+    return [last, ...services, first];
+  }, [serviceCount, services]);
+
+  useEffect(() => {
+    setDisplayIndex(serviceCount ? 1 : 0);
+  }, [serviceCount]);
+
+  useEffect(() => {
+    if (!serviceCount) return;
+    if (displayIndex === 0) {
+      const id = requestAnimationFrame(() => {
+        setIsTransitionEnabled(false);
+        setDisplayIndex(serviceCount);
+      });
+      return () => cancelAnimationFrame(id);
+    }
+    if (displayIndex === serviceCount + 1) {
+      const id = requestAnimationFrame(() => {
+        setIsTransitionEnabled(false);
+        setDisplayIndex(1);
+      });
+      return () => cancelAnimationFrame(id);
+    }
+
+    if (!isTransitionEnabled) {
+      const id = requestAnimationFrame(() => {
+        setIsTransitionEnabled(true);
+      });
+      return () => cancelAnimationFrame(id);
+    }
+  }, [displayIndex, serviceCount, isTransitionEnabled]);
 
   return (
     <section
@@ -92,6 +173,7 @@ export function ServicesSection() {
     >
       <div className="mx-auto w-full px-0">
         <div
+          ref={containerRef}
           className="relative left-1/2 w-screen -translate-x-1/2 overflow-hidden pb-6"
           style={{ touchAction: "pan-y" }}
           onPointerDown={(event) => {
@@ -120,37 +202,93 @@ export function ServicesSection() {
           }}
         >
           <div
-            className="flex transition-transform duration-500 ease-out"
-            style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+            className="flex transition-transform ease-out"
+            style={{
+              transform: `translateX(-${displayIndex * (cardWidth + gap)}px)`,
+              gap: gap ? `${gap}px` : undefined,
+              padding: sidePadding ? `0 ${sidePadding}px` : undefined,
+              transitionDuration: isTransitionEnabled ? "500ms" : "0ms",
+            }}
           >
-            {services.map((service, index) => (
-              <Card
-                key={index}
-                className="flex min-w-full flex-shrink-0 flex-col overflow-hidden rounded-none border-none bg-transparent shadow-none backdrop-blur-0 animate-fade-in"
-                data-testid={`card-service-${index}`}
-              >
-                <div className="relative w-full overflow-hidden aspect-video">
-                  {String(service.media).toLowerCase().endsWith(".mp4") ? (
-                    <VideoWithPreview
-                      src={service.media as string}
-                      className="block h-full w-full object-cover"
-                      preload="auto"
-                    />
-                  ) : (
-                    <img
-                      src={service.media as any}
-                      alt={service.title}
-                      className="block h-full w-full object-cover"
-                    />
-                  )}
-                </div>
-                <CardContent className="px-6 py-6">
-                  <h4 className="mb-4 text-center text-xl font-bold">{service.title}</h4>
-                  <p className="text-muted-foreground">{service.description}</p>
-                </CardContent>
-              </Card>
-            ))}
+            {extendedServices.map((service, index) => {
+              const isClone =
+                serviceCount > 0 &&
+                (index === 0 || index === extendedServices.length - 1);
+              const actualIndex =
+                serviceCount === 0
+                  ? 0
+                  : index === 0
+                    ? serviceCount - 1
+                    : index === extendedServices.length - 1
+                      ? 0
+                      : index - 1;
+
+              return (
+                <Card
+                  key={`${service.title}-${index}`}
+                  className="flex flex-shrink-0 flex-col overflow-hidden rounded-none border-none bg-transparent shadow-none backdrop-blur-0 animate-fade-in"
+                  style={{ width: cardWidth ? `${cardWidth}px` : "80vw" }}
+                  data-testid={
+                    !isClone ? `card-service-${actualIndex}` : undefined
+                  }
+                >
+                  <div className="relative w-full overflow-hidden aspect-video">
+                    {String(service.media).toLowerCase().endsWith(".mp4") ? (
+                      <VideoWithPreview
+                        src={service.media as string}
+                        className="block h-full w-full object-cover"
+                        preload="auto"
+                      />
+                    ) : (
+                      <img
+                        src={service.media as any}
+                        alt={service.title}
+                        className="block h-full w-full object-cover"
+                      />
+                    )}
+                    </div>
+                    <CardContent className="px-6 py-6">
+                      <h4 className="mb-4 text-center text-xl font-bold">{service.title}</h4>
+                      <p className="text-muted-foreground">{service.description}</p>
+                    </CardContent>
+                  </Card>
+                );
+            })}
           </div>
+          <button
+            type="button"
+            className="pointer-events-auto absolute left-2 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/40 text-2xl text-white transition hover:bg-black/60"
+            aria-label="이전 서비스"
+            onPointerDown={(event) => {
+              event.stopPropagation();
+            }}
+            onPointerUp={(event) => {
+              event.stopPropagation();
+            }}
+            onClick={(event) => {
+              event.stopPropagation();
+              goToPrev();
+            }}
+          >
+            &lt;
+          </button>
+          <button
+            type="button"
+            className="pointer-events-auto absolute right-2 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/40 text-2xl text-white transition hover:bg-black/60"
+            aria-label="다음 서비스"
+            onPointerDown={(event) => {
+              event.stopPropagation();
+            }}
+            onPointerUp={(event) => {
+              event.stopPropagation();
+            }}
+            onClick={(event) => {
+              event.stopPropagation();
+              goToNext();
+            }}
+          >
+            &gt;
+          </button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- resize service cards to ~80% of the viewport and display adjacent previews while keeping responsive padding
- add infinite looping swipe/tap navigation with clickable edge controls for previous/next transitions
- show edge navigation icons and react to container resizes to keep card dimensions in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d76160ca8c832dbacb9d3ff3dee430