### PR TITLE
Fix service card centering

### DIFF
--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -172,15 +172,10 @@ export function ServicesSection() {
   const previewDistance = useMemo(() => {
     if (!serviceCount || previewOffset === 0) return 0;
 
-    const isAtStartClone = displayIndex === 0;
-    const isAtFirstCard = displayIndex === 1;
-    const isAtEndClone = displayIndex === serviceCount + 1;
+    const isClonePosition =
+      displayIndex === 0 || displayIndex === serviceCount + 1;
 
-    if (isAtStartClone || isAtFirstCard || isAtEndClone) {
-      return previewOffset;
-    }
-
-    return 0;
+    return isClonePosition ? previewOffset : 0;
   }, [displayIndex, previewOffset, serviceCount]);
 
   const translateX = useMemo(() => {


### PR DESCRIPTION
## Summary
- adjust the preview offset logic so the 첫 번째 서비스 카드 remains centered while keeping clone previews intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76c20c170832d9189c448c70df2bd