### PR TITLE
Fix services carousel blank screen on rapid swipes

### DIFF
--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -42,12 +42,12 @@ export function ServicesSection() {
 
   const goToNext = () => {
     if (serviceCount === 0) return;
-    setDisplayIndex((prev) => prev + 1);
+    setDisplayIndex((prev) => Math.min(prev + 1, serviceCount + 1));
   };
 
   const goToPrev = () => {
     if (serviceCount === 0) return;
-    setDisplayIndex((prev) => prev - 1);
+    setDisplayIndex((prev) => Math.max(prev - 1, 0));
   };
 
   const handlePointerDown = (clientX: number) => {


### PR DESCRIPTION
## Summary
- prevent the services carousel index from exceeding the cloned slide range when swiping rapidly

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d76de77248832d8a7a8983bc8820c2