### PR TITLE
Fix services carousel overscroll when looping

### DIFF
--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -172,10 +172,15 @@ export function ServicesSection() {
   const previewDistance = useMemo(() => {
     if (!serviceCount || previewOffset === 0) return 0;
 
-    const isClonePosition =
-      displayIndex === 0 || displayIndex === serviceCount + 1;
+    if (displayIndex === 0) {
+      return previewOffset;
+    }
 
-    return isClonePosition ? previewOffset : 0;
+    if (displayIndex === serviceCount + 1) {
+      return -previewOffset;
+    }
+
+    return 0;
   }, [displayIndex, previewOffset, serviceCount]);
 
   const translateX = useMemo(() => {


### PR DESCRIPTION
## Summary
- adjust the preview offset handling for cloned slides so the carousel wraps without overscrolling past the first card

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d7702b676c832dad6fe6cb0bd1ce49