### PR TITLE
Align service card typography with gallery

### DIFF
--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -275,8 +275,12 @@ export function ServicesSection() {
                     )}
                     </div>
                     <CardContent className="px-6 py-6">
-                      <h4 className="mb-4 text-center text-xl font-bold">{service.title}</h4>
-                      <p className="text-muted-foreground">{service.description}</p>
+                      <h4 className="mb-4 text-center text-2xl font-semibold">
+                        {service.title}
+                      </h4>
+                      <p className="text-base leading-relaxed text-muted-foreground">
+                        {service.description}
+                      </p>
                     </CardContent>
                   </Card>
                 );


### PR DESCRIPTION
## Summary
- match the 서비스 섹션 카드 제목과 본문 폰트 크기를 갤러리 섹션 스타일과 일치하도록 조정

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d773463810832d9e8839604842ffb1